### PR TITLE
Only use the SESSION_SECRET env variable in production

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -9,8 +9,10 @@ module PowerGPA
   class Application < ::Sinatra::Base
     enable :logging
     enable :sessions
-    set :session_secret, ENV['SESSION_SECRET']
     set :show_exceptions, :after_handler
+    configure :production do
+      set :session_secret, ENV['SESSION_SECRET']
+    end
 
     get '/' do
       @current_error = request.session['powergpa.error']


### PR DESCRIPTION
Previously, when the environment variable was not set in development, the following error occurred:

```
17:11:46 web.1  |         SECURITY WARNING: No secret option provided to Rack::Session::Cookie.
17:11:46 web.1  |         This poses a security threat. It is strongly recommended that you
17:11:46 web.1  |         provide a secret to prevent exploits that may be possible from crafted
17:11:46 web.1  |         cookies. This will not be supported in future versions of Rack, and
17:11:46 web.1  |         future versions will even invalidate your existing user cookies.
17:11:46 web.1  | 
17:11:46 web.1  |         Called from: /Users/jon/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/builder.rb:86:in `new'.
17:11:46 web.1  | 127.0.0.1 - - [20/Oct/2016:17:11:46 -0400] "GET / HTTP/1.1" 200 6484 0.0129
```
