### PR TITLE
Fix [RB-6]

### DIFF
--- a/lib/grade_fetcher.rb
+++ b/lib/grade_fetcher.rb
@@ -16,7 +16,7 @@ module PowerGPA
       if @params[:ps_username] == 'fakestudent123'
         FakeStudentGradeFetcher.grades
       else
-        api = APIClient.new(@params[:ps_url], @params[:ps_username], @params[:ps_password], @params[:ps_type])
+        api = APIClient.new(@params[:ps_url].downcase, @params[:ps_username], @params[:ps_password], @params[:ps_type])
         api.connect
         api.grades
       end


### PR DESCRIPTION
Downcases the URL. On mobile devices, the keyboard usually auto
capitalizes the first letter, which is leading to errors such as `URI::InvalidURIError`.
