### PR TITLE
Fix [RB-5]

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -53,8 +53,13 @@ module PowerGPA
     end
 
     error 500 do
-      RollbarReporter.call(env)
-      request.session['powergpa.error'] = true
+      if $!.class == APIClient::IncorrectCredentialsError
+        request.session['powergpa.error'] = :invalid_credentials
+      else
+        RollbarReporter.call(env)
+        request.session['powergpa.error'] = :unknown
+      end
+
       redirect '/'
     end
 

--- a/views/error.erb
+++ b/views/error.erb
@@ -1,0 +1,14 @@
+<div class="alert alert-dismissible alert-info">
+  <button type="button" class="close" data-dismiss="alert">×</button>
+  <strong>Whoops!</strong>
+
+  <% if @current_error == :unknown %>
+    An error ocurred while we were trying to calculate your GPA.
+      Double check that you typed your information into the form,
+      and then try submitting again.
+  <% elsif @current_error == :invalid_credentials %>
+    Looks like you typed in a wrong username or password.
+      Double check that you typed in your credentials correctly, and then try
+      submitting again.
+  <% end %>
+</div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,14 +1,7 @@
 <div class="row powergpa-row" style="font-family: 'Muli', sans-serif; border-radius: 0 !important; -moz-border-radius: 0 !important;">
   <div class="col-md-6 col-md-offset-3 col-xs-10 col-xs-offset-1">
     <% if @current_error %>
-      <div class="alert alert-dismissible alert-info">
-        <button type="button" class="close" data-dismiss="alert">×</button>
-
-        <strong>Whoops!</strong>
-        An error ocurred while we were trying to calculate your GPA.
-        Double check that you typed your information into the form,
-        and then try submitting again.</h1>
-      </div>
+      <%= erb :error %>
     <% end %>
 
     <ul class="list-group">


### PR DESCRIPTION
Created `PowerGPA::APIClient::IncorrectCredentialsError` error class.
Within the `error` block, we now check for this specific error message
and will return a special error message if invalid credentials are
entered. We will also, from this point forward, exclude this error from
being reported in Rollbar, due to the fact that we can do nothing about
it.
