### PR TITLE
Remove students if their grade info is empty

### DIFF
--- a/lib/power_gpa/application.rb
+++ b/lib/power_gpa/application.rb
@@ -83,6 +83,10 @@ module PowerGPA
           end
         end
 
+        @students.reject! do |name, info|
+          info['grade_info'].empty?
+        end
+
         Librato.increment 'gpa.calculate.count'
 
         erb :gpa


### PR DESCRIPTION
If there are no grades (and thus no GPA) to show, then remove them.
