### PR TITLE
Don't try and read credentials if none exist

### DIFF
--- a/lib/power_gpa/application.rb
+++ b/lib/power_gpa/application.rb
@@ -121,6 +121,8 @@ module PowerGPA
       def read_credentials
         return_value = {}
 
+        return return_value if !request.session['powergpa.credentials']
+
         begin
           request.session['powergpa.credentials'].each do |k, v|
             return_value[k] = encryptor.decrypt_and_verify(v)


### PR DESCRIPTION
Fixes RB-29.

`NoMethodError: undefined method `each' for nil:NilClass`