### PR TITLE
Ditch "remember me"

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -66,19 +66,6 @@
       </li>
       <li class="list-group-item">
         <div class="row">
-          <div class="form-group">
-            <div class="col-md-1 col-md-offset-1 col-xs-offset-1">
-              <label for="select" class="control-label" style="text-align: right;">Remember Me:</label>
-            </div>
-            <div class="col-md-1 col-xs-offset-1 col-xs-1">
-              <br>
-              <input type="checkbox" name="ps_remember" style="text-decoration: none !important;"></input>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li class="list-group-item">
-        <div class="row">
           <div class="col-md-2 col-xs-offset-1 col-md-offset-0">
             <button class="btn btn-primary" id="calc">Calculate GPA</button>
           </div>

--- a/views/nav.erb
+++ b/views/nav.erb
@@ -17,10 +17,9 @@
         <li><a href="/">Home</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="https://github.com/menai/PowerGPA/issues/new">Report a bug</a></li>
+
         <% if stored_credentials? %>
           <li><a href="/clear_credentials">Log out</a></li>
-        <% elsif request.path == '/gpa' %>
-          <li><a href="/">Log out</a></li>
         <% end %>
       </ul>
 


### PR DESCRIPTION
Since we now store user credentials in the session by default, in order
to provide authentication for the marking period switcher feature, IMHO
it makes sense to remove the "remember me" feature, since we need to
save this information anyway to power the site.