### PR TITLE
Introduce `CorruptedDataError`

### DIFF
--- a/lib/power_gpa/api_client.rb
+++ b/lib/power_gpa/api_client.rb
@@ -6,6 +6,9 @@ require 'power_gpa/api_client/student_data_fetcher'
 
 module PowerGPA
   class APIClient
+    class CorruptedDataError < StandardError
+    end
+
     class InvalidCredentialsError < StandardError
     end
 
@@ -41,9 +44,8 @@ module PowerGPA
 
       begin
         login = client.call(:login, message: { username: @username, password: @password, userType: @type } )
-      rescue Savon::SOAPFault => e
-        RollbarReporter.scope!({ soap_error_hash: e.to_hash })
-        raise e
+      rescue Savon::SOAPFault
+        raise CorruptedDataError
       end
 
       if bad_credentials?(login)

--- a/lib/power_gpa/application.rb
+++ b/lib/power_gpa/application.rb
@@ -59,7 +59,7 @@ module PowerGPA
     end
 
     get '/clear_credentials' do
-      request.session['powergpa.credentials'] = nil
+      clear_credentials
       redirect '/'
     end
 
@@ -72,6 +72,8 @@ module PowerGPA
         request.session['powergpa.error'] = :invalid_credentials
       elsif $!.class == APIClient::InvalidURLError
         request.session['powergpa.error'] = :invalid_url
+      elsif $!.class == APIClient::CorruptedDataError
+        clear_credentials
       else
         RollbarReporter.call(env)
         request.session['powergpa.error'] = :unknown
@@ -95,6 +97,10 @@ module PowerGPA
         end
 
         erb :gpa
+      end
+
+      def clear_credentials
+        request.session['powergpa.credentials'] = nil
       end
 
       def encryptor


### PR DESCRIPTION
This error will be raised if invalid data is passed to the Savon login
client. This most commonly occurs when a user's cookies somehow get
messed up and are nil-ed, thus causing PowerGPA to error while trying to
use this now bad credentials.