### PR TITLE
finalGrades must always be an Array

### DIFF
--- a/lib/power_gpa/api_client/student_data_fetcher.rb
+++ b/lib/power_gpa/api_client/student_data_fetcher.rb
@@ -124,6 +124,10 @@ module PowerGPA
           end
         end
 
+        if !data['finalGrades'].is_a?(Array)
+          data['finalGrades'] = [data['finalGrades']]
+        end
+
         data['finalGrades'].each do |grade|
           if valid_grade?(grade, courses, terms_for_data_ids)
             final_grades[courses.key(grade['sectionid'])] = grade['percent']


### PR DESCRIPTION
Otherwise you are doing an `each` with a `Hash` which can turn nasty.
Original error caused when `data['finalGrades']` is a `Hash`.